### PR TITLE
Add Timeline Posts Page with Gravatar

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,7 +11,10 @@ env = Environment(
     autoescape=select_autoescape()
 )
 
+# load env variables
 load_dotenv()
+
+# create flask app instance
 app = Flask(__name__)
 
 # connect to database using MySQLDatabase function from peewee
@@ -34,6 +37,7 @@ class TimelinePost(Model):
     class Meta:
         database = mydb
 
+# connect to database and create tables
 mydb.connect()
 mydb.create_tables([TimelinePost])
 
@@ -222,3 +226,7 @@ def delete_time_line_post(post_id):
         return {"message": "Post deleted"}, 200
     else:
         return {"message": "Post not found"}, 404
+
+@app.route('/timeline')
+def timeline():
+    return render_template('timeline.html', title="Timeline")

--- a/app/templates/timeline.html
+++ b/app/templates/timeline.html
@@ -25,43 +25,60 @@
       const postsDiv = document.getElementById('posts');
       postsDiv.innerHTML = '';
 
+      // SHA256 hashing foor Gravatar
+      async function getSHA256Hash(email) {
+        // normalize the email
+        const textAsBuffer = new TextEncoder().encode(
+          email.trim().toLowerCase()
+        );
+        // hash the normalized email using browser's Web Crypto API (SHA-256), returns an ArrayBuffer
+        const hashBuffer = await crypto.subtle.digest('SHA-256', textAsBuffer);
+        // convert the ArrayBuffer to a byte array (Unit8Array)
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        // convert each byte to a two-character hexadecimal string
+        // join to form the full SHA-256 hext string
+        const hash = hashArray
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('');
+        return hash;
+      }
+
+      // render a post with Gravatar
+      async function renderPost(post) {
+        const hash = await getSHA256Hash(post.email);
+        const gravatarUrl = `https://gravatar.com/avatar/${hash}?s=64&d=identicon`;
+
+        const div = document.createElement('div');
+        div.innerHTML = `<img src="${gravatarUrl}" alt="Profile" width="40" height="40"/>
+        <strong>${post.name}</strong> (${post.email}): ${post.content}`;
+        return div;
+      }
+
       // fetch and display existing posts
       async function fetchPosts() {
         const response = await fetch('/api/timeline_post');
         const data = await response.json();
 
-        data.timeline_post.forEach((post) => {
-          const div = document.createElement('div');
-          div.innerHTML = `<p>${post.name}, ${post.email}, ${post.content}</p>`;
-
-          postsDiv.appendChild(div);
-        });
-      }
-
-      // render a post
-      function renderPost(post) {
-        const div = document.createElement('div');
-        div.innerHTML = `<p>${post.name}, ${post.email}, ${post.content}</p>`;
-        return div;
+        postsDiv.innerHTML = '';
+        for (const post of data.timeline_post) {
+          postsDiv.appendChild(await renderPost(post));
+        }
       }
 
       // handle form submission
       const form = document.getElementById('timeline-form');
-
       form.addEventListener('submit', async function (e) {
         e.preventDefault();
-
         const formData = new FormData(form);
-
         const response = await fetch('/api/timeline_post', {
           method: 'POST',
           body: formData,
         });
-
         const post = await response.json();
 
         // add new post to top
-        postsDiv.insertBefore(renderPost(post), postsDiv.firstChild);
+        const postDiv = await renderPost(post);
+        postsDiv.insertBefore(postDiv, postsDiv.firstChild);
 
         form.reset();
       });

--- a/app/templates/timeline.html
+++ b/app/templates/timeline.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Timeline Posts</title>
+  </head>
+  <body>
+    <p>Timeline Posts</p>
+    <form action="/api/timeline_post" method="POST" id="timeline-form">
+      <label for="name">
+        Name: <input type="text" name="name" value="" id="name" /> </label
+      ><br />
+      <label for="email"
+        >Email: <input type="email" name="email" value="" id="email" /> </label
+      ><br />
+      <label for="content"
+        >Content:
+        <input type="text" name="content" value="" id="content" /> </label
+      ><br />
+      <button type="submit">Submit</button>
+    </form>
+    <div id="posts"></div>
+    <script>
+      const postsDiv = document.getElementById('posts');
+      postsDiv.innerHTML = '';
+
+      // fetch and display existing posts
+      async function fetchPosts() {
+        const response = await fetch('/api/timeline_post');
+        const data = await response.json();
+
+        data.timeline_post.forEach((post) => {
+          const div = document.createElement('div');
+          div.innerHTML = `<p>${post.name}, ${post.email}, ${post.content}</p>`;
+
+          postsDiv.appendChild(div);
+        });
+      }
+
+      // render a post
+      function renderPost(post) {
+        const div = document.createElement('div');
+        div.innerHTML = `<p>${post.name}, ${post.email}, ${post.content}</p>`;
+        return div;
+      }
+
+      // handle form submission
+      const form = document.getElementById('timeline-form');
+
+      form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+
+        const formData = new FormData(form);
+
+        const response = await fetch('/api/timeline_post', {
+          method: 'POST',
+          body: formData,
+        });
+
+        const post = await response.json();
+
+        // add new post to top
+        postsDiv.insertBefore(renderPost(post), postsDiv.firstChild);
+
+        form.reset();
+      });
+
+      fetchPosts();
+    </script>
+  </body>
+</html>

--- a/app/templates/timeline.html
+++ b/app/templates/timeline.html
@@ -50,7 +50,7 @@
 
         const div = document.createElement('div');
         div.innerHTML = `<img src="${gravatarUrl}" alt="Profile" width="40" height="40"/>
-        <strong>${post.name}</strong> (${post.email}): ${post.content}`;
+        <strong>${post.name}</strong> (${post.email}): ${post.content} - ${post.created_at}`;
         return div;
       }
 

--- a/scripts/curl-test.sh
+++ b/scripts/curl-test.sh
@@ -1,4 +1,4 @@
-# #!/bin/bash
+#!/bin/bash
 
 # create a post and get the ID
 POST_RESPONSE=$(curl -s -X POST http://127.0.0.1:5000/api/timeline_post -d 'name=Random&email=random@email.com&content=This is a random message.')


### PR DESCRIPTION
Added `timeline.html` file for Timeline Posts Page that accepts inputs. Users can make POST request to `/api/timeline_post` endpoint to create a timeline post. Beneath the form, all the timeline posts will be listed in the descending order. Implemented Gravatar to display users' profile images based on email.